### PR TITLE
Update navigation flows and protected routes for `Comunicados` alignment

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -58,7 +58,7 @@ function App() {
           {/* Rotas protegidas dentro do Layout */}
           <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
             {/* Rotas de Usuário */}
-            <Route index element={<UserDashboard />} />
+            <Route index element={<Comunicados />} />
             <Route path="feedbacks" element={<UserDashboard />} />
             <Route path="comunicados" element={<Comunicados />} />
             <Route path="meu-pdi" element={<AllPDIs />} />
@@ -66,14 +66,14 @@ function App() {
             <Route path="pdi" element={<AllPDIs />} />
 
             {/* Rotas de Admin */}
-            <Route path="admin" element={<ProtectedRoute role="admin"><AdminDashboard /></ProtectedRoute>} />
+            <Route path="admin" element={<Navigate to="/admin/comunicados" replace />} />
             <Route path="admin/users" element={<ProtectedRoute role="admin"><UserManagement /></ProtectedRoute>} />
             <Route path="admin/comunicados" element={<ProtectedRoute role="admin"><ComunicadosManagement /></ProtectedRoute>} />
             <Route path="admin/feedbacks" element={<ProtectedRoute role="admin"><FeedbackManagement /></ProtectedRoute>} />
             <Route path="admin/relatorios" element={<ProtectedRoute role="admin"><AdminDashboard /></ProtectedRoute>} />
 
             {/* Rotas de Gestor */}
-            <Route path="gestor" element={<ProtectedRoute role="gestor"><GestorDashboard /></ProtectedRoute>} />
+            <Route path="gestor" element={<Navigate to="/comunicados" replace />} />
 
             {/* Rota para páginas não encontradas dentro do layout */}
             <Route path="*" element={<Oops />} />

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -30,10 +30,10 @@ const Login = () => {
       const role = user.role;
       switch (role) {
         case 'admin':
-          navigate('/admin');
+          navigate('/admin/comunicados');
           break;
         case 'gestor':
-          navigate('/gestor');
+          navigate('/');
           break;
         case 'colaborador':
           navigate('/');

--- a/src/hooks/useAuthNavigation.js
+++ b/src/hooks/useAuthNavigation.js
@@ -8,13 +8,13 @@ export const useAuthNavigation = () => {
   const redirectBasedOnRole = (role) => {
     switch (role) {
       case 'admin':
-        navigate('/admin');
+        navigate('/admin/comunicados');
         break;
       case 'gestor':
-        navigate('/comunicados');
+        navigate('/');
         break;
       case 'colaborador':
-        navigate('/comunicados');
+        navigate('/');
         break;
       default:
         navigate('/login');


### PR DESCRIPTION
- Adjust role-based redirects in `useAuthNavigation` to align admin, gestor, and colaborador paths with updated `Comunicados`.
- Update default route for `/admin` and `/gestor` paths to point to `Comunicados` pages.
- Replace `UserDashboard` with `Comunicados` as the default user route in `App.js`.